### PR TITLE
Add parameterless call for 'bd' to go one dir up

### DIFF
--- a/PoShAncestry.psm1
+++ b/PoShAncestry.psm1
@@ -78,7 +78,7 @@ https://github.com/DuFace/PoShAncestry
 function Select-Ancestor {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$false)]
         [String]
         $Ancestor,
 
@@ -92,6 +92,11 @@ function Select-Ancestor {
     )
 
     process {
+        if (-not $Ancestor)
+        {
+            return Set-Location -Path ".."
+        }
+
         # Split the current path into a list of directories
         $parts = GetAncestors
 


### PR DESCRIPTION
It is easiear to learn to use new command if we can replace widely used 'cd ..' with just 'bd'.
